### PR TITLE
correct Stack's move-assign-operator declaration

### DIFF
--- a/pdCalc/src/backend/Stack.h
+++ b/pdCalc/src/backend/Stack.h
@@ -70,7 +70,7 @@ private:
     Stack(const Stack&) = delete;
     Stack(Stack&&) = delete;
     Stack& operator=(const Stack&) = delete;
-    Stack& operator=(const Stack&&) = delete;
+    Stack& operator=(Stack&&) = delete;
 
     std::unique_ptr<StackImpl> pimpl_;
 };


### PR DESCRIPTION
remove the const keyword